### PR TITLE
Simplify deployment by embedding assets into library.

### DIFF
--- a/ekg.cabal
+++ b/ekg.cabal
@@ -13,14 +13,14 @@ maintainer:          johan.tibell@gmail.com
 category:            System, Network
 build-type:          Simple
 cabal-version:       >=1.6
-data-files:          assets/index.html assets/monitor.js assets/monitor.css
-                     assets/jquery.flot.min.js assets/jquery-1.6.4.min.js
-                     assets/bootstrap-1.4.0.min.css
-                     assets/chart_line_add.png assets/cross.png
 extra-source-files:  LICENSE.icons LICENSE.javascript README.md
                      assets/jquery-1.6.4.js assets/jquery.flot.js
                      examples/Basic.hs
 
+                     assets/index.html assets/monitor.js assets/monitor.css
+                     assets/jquery.flot.min.js assets/jquery-1.6.4.min.js
+                     assets/bootstrap-1.4.0.min.css
+                     assets/chart_line_add.png assets/cross.png
 library
   exposed-modules:     System.Remote.Counter
                        System.Remote.Gauge
@@ -45,7 +45,9 @@ library
                        text < 0.12,
                        time < 1.5,
                        transformers < 0.4,
-                       unordered-containers < 0.3
+                       unordered-containers < 0.3,
+                       file-embed == 0.0.*,
+                       directory < 1.3
   ghc-options:         -Wall
 
 source-repository head


### PR DESCRIPTION
Hi Johan,

we would like to use `ekg` at Erudify to monitor services deployed in our cloud. However, it's reliance on extra data files makes deploying applications built using it unnecessarily difficult. The attached patch uses the [`file-embed`](http://hackage.haskell.org/package/file-embed) library to embed the necessary assets directly into the `ekg` library at compile time. 

It would be great, if you could change `ekg` to use this scheme. If required, then I can add either a cabal flag that allows to compile without embedding the files, or I can add an additional argument to `startServer`, which allows to specify the assets directory. I guess one would typically use the latter for development of the default monitor or for using a simple custom monitor. However, I do expect that for almost all use cases this direct embedding of the assets is the most convenient option.

What do you think?

best regards,
Simon
