### PR TITLE
Bumped network and ekg upper bound

### DIFF
--- a/ekg.cabal
+++ b/ekg.cabal
@@ -42,7 +42,7 @@ library
     bytestring < 1.0,
     ekg-core >= 0.1 && < 0.2,
     filepath < 1.4,
-    network <= 2.5,
+    network < 2.6,
     snap-core < 0.10,
     snap-server < 0.10,
     text < 1.2,


### PR DESCRIPTION
ekg version bump for `network-2.5.0.0`.
