### PR TITLE
Correct a JavaScript exception for empty distributions

### DIFF
--- a/assets/monitor.js
+++ b/assets/monitor.js
@@ -293,8 +293,13 @@ $(document).ready(function () {
             }
             if (!paused) {
                 if (value.type === DISTRIBUTION) {
-                    var val = value.mean.toPrecision(8) + '\n+/-' +
-                        Math.sqrt(value.variance).toPrecision(8) + ' sd';
+                    if (value.mean !== null) {
+                        var val = value.mean.toPrecision(8) + '\n+/-' +
+                            Math.sqrt(value.variance).toPrecision(8) + ' sd';
+                    }
+                    else {
+                        var val = "N/A";
+                    }
                 } else {  // COUNTER, GAUGE, LABEL
                     var val = value.val;
                 }


### PR DESCRIPTION
If you create a distribution but don't write to it, the mean of the
distribution is NaN - which Aeson encodes as `null`. Thus we have to
make sure that when working with the mean, we check for `null`.
