### PR TITLE
Also distribute bootstrap non-minified in archives

### DIFF
--- a/ekg.cabal
+++ b/ekg.cabal
@@ -20,6 +20,7 @@ data-files:          assets/index.html assets/monitor.js assets/monitor.css
                      assets/chart_line_add.png assets/cross.png
 extra-source-files:  LICENSE.icons LICENSE.javascript README.md
                      assets/jquery-1.6.4.js assets/jquery.flot.js
+                     assets/bootstrap-1.4.0.css
                      examples/Basic.hs CHANGES.md
 cabal-version:       >= 1.8
 


### PR DESCRIPTION
Commit 6ae685e added the non-minified bootstrap source to the repository, but it's still not distributed in the generated archive; which means that for Debian, issue #20 is not quite closed yet.
