### PR TITLE
Expose Json module and Snap module/functions

### DIFF
--- a/System/Remote/Snap.hs
+++ b/System/Remote/Snap.hs
@@ -2,6 +2,12 @@
 
 module System.Remote.Snap
     ( startServer
+    , getNumericHostAddress
+    , monitor
+    , acceptHeader
+    , format
+    , serve
+    , parseHttpAccept
     ) where
 
 import Control.Applicative ((<$>), (<|>))

--- a/ekg.cabal
+++ b/ekg.cabal
@@ -27,13 +27,15 @@ tested-with:         GHC == 8.0.1, GHC == 7.10.1, GHC == 7.8.4, GHC == 7.6.3
 
 library
   exposed-modules:
-    Paths_ekg
     System.Remote.Counter
     System.Remote.Gauge
     System.Remote.Json
     System.Remote.Label
     System.Remote.Monitoring
     System.Remote.Snap
+
+  other-modules:
+    Paths_ekg
 
   build-depends:
     aeson < 0.12,

--- a/ekg.cabal
+++ b/ekg.cabal
@@ -27,14 +27,12 @@ tested-with:         GHC == 8.0.1, GHC == 7.10.1, GHC == 7.8.4, GHC == 7.6.3
 
 library
   exposed-modules:
+    Paths_ekg
     System.Remote.Counter
     System.Remote.Gauge
+    System.Remote.Json
     System.Remote.Label
     System.Remote.Monitoring
-
-  other-modules:
-    Paths_ekg
-    System.Remote.Json
     System.Remote.Snap
 
   build-depends:


### PR DESCRIPTION
We're hoping to embed ekg in our snap application under a sub-path but currently that's not possible due to the hidden modules/functions.