### PR TITLE
Removed setHostname and setBind from the Snap configuration.

### DIFF
--- a/System/Remote/Snap.hs
+++ b/System/Remote/Snap.hs
@@ -73,6 +73,7 @@ format fmt action = do
 serve :: MonadSnap m => Store -> m ()
 serve store = do
     req <- getRequest
+    liftIO $ print req
     modifyResponse $ setContentType "application/json"
     if S.null (rqPathInfo req)
         then serveAll

--- a/System/Remote/Snap.hs
+++ b/System/Remote/Snap.hs
@@ -73,7 +73,6 @@ format fmt action = do
 serve :: MonadSnap m => Store -> m ()
 serve store = do
     req <- getRequest
-    liftIO $ print req
     modifyResponse $ setContentType "application/json"
     if S.null (rqPathInfo req)
         then serveAll


### PR DESCRIPTION
This fixes #46 by removing the setHostname and setBind, I believe related to the setBind issue setHostname causes 404s to be returned.

With the setHostname I found that requesting the ekg root from within the process and printing it out worked outside Docker, but within a Docker container gave me a 404.
