### PR TITLE
Support aeson 1.0.

### DIFF
--- a/ekg.cabal
+++ b/ekg.cabal
@@ -38,7 +38,7 @@ library
     System.Remote.Snap
 
   build-depends:
-    aeson < 0.12,
+    aeson < 1.1,
     base >= 4.5 && < 4.10,
     bytestring < 1.0,
     ekg-core >= 0.1 && < 0.2,


### PR DESCRIPTION
This PR bumps the upper bound on aeson to 1.1. Everything builds fine, with three deprecation warnings:

```
[1 of 7] Compiling System.Remote.Json ( System/Remote/Json.hs, .stack-work/dist/x86_64-osx/Cabal-1.22.5.0/build/System/Remote/Json.o )

/Users/rob/Developer/GitHub/semantic-diff/.stack-work/downloaded/mOmuIfh88N2u/System/Remote/Json.hs:7:1: Warning:
    Module ‘Data.Aeson.Encode’ is deprecated:
      Use Data.Aeson or Data.Aeson.Text instead

/Users/rob/Developer/GitHub/semantic-diff/.stack-work/downloaded/mOmuIfh88N2u/System/Remote/Json.hs:16:13: Warning:
    In the use of ‘A.encode’ (imported from Data.Aeson.Encode):
    Deprecated: "Use Data.Aeson or Data.Aeson.Text instead"

/Users/rob/Developer/GitHub/semantic-diff/.stack-work/downloaded/mOmuIfh88N2u/System/Remote/Json.hs:21:13: Warning:
    In the use of ‘A.encode’ (imported from Data.Aeson.Encode):
    Deprecated: "Use Data.Aeson or Data.Aeson.Text instead"
```

and one other warning which I _think_ is unrelated:

```
/Users/rob/Developer/GitHub/semantic-diff/.stack-work/downloaded/mOmuIfh88N2u/System/Remote/Snap.hs:7:1: Warning:
    The import of ‘<$>’ from module ‘Control.Applicative’ is redundant
```

Thank you for your time :bow:
