### PR TITLE
Expose System.Remote.Snap for its `startServer` definition, for the benefit of #50

### DIFF
--- a/ekg.cabal
+++ b/ekg.cabal
@@ -33,11 +33,11 @@ library
     System.Remote.Gauge
     System.Remote.Label
     System.Remote.Monitoring
+    System.Remote.Snap
 
   other-modules:
     Paths_ekg
     System.Remote.Json
-    System.Remote.Snap
 
   build-depends:
     aeson >= 0.4 && < 1.5,


### PR DESCRIPTION
Allow `startServer` to be called directly, to allow proper exception handling.