### PR TITLE
Bump base for GHC 8.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .cabal-sandbox/
 .hpc/
 /dist/*
+/dist-newstyle/*
 cabal.config
 cabal.sandbox.config
 examples/Basic

--- a/ekg.cabal
+++ b/ekg.cabal
@@ -41,7 +41,7 @@ library
 
   build-depends:
     aeson >= 0.4 && < 1.5,
-    base >= 4.5 && < 4.14,
+    base >= 4.5 && < 4.15,
     bytestring < 1.0,
     ekg-core >= 0.1 && < 0.2,
     ekg-json >= 0.1 && < 0.2,


### PR DESCRIPTION
Addresses https://github.com/tibbe/ekg/issues/81 . `cabal build` succeeds now.