### PR TITLE
Throw startServer exceptions synchronously

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "haskell.serverExecutablePath": "/Users/pepeiborra/scratch/ide/dist-newstyle/build/x86_64-osx/ghc-8.10.5/ghcide-1.4.2.3/x/ghcide/build/ghcide/ghcide"
+}

--- a/ekg.cabal
+++ b/ekg.cabal
@@ -41,6 +41,7 @@ library
 
   build-depends:
     aeson >= 0.4 && < 1.6,
+    async,
     base >= 4.5 && < 4.15,
     bytestring < 1.0,
     ekg-core >= 0.1 && < 0.2,


### PR DESCRIPTION
Error handling doesn't currently work with `forkServer`:
```
do
  s <- Just <$> forkServer "localhost" 8000 `catchAny` \e -> pure Nothing
```

The above code will not manage to deal with "port already in use" or similar, since the exceptions are being thrown asynchronously to the main thread.

To address that we use an Async to hold the server, so there's no longer a need to throw the exception back to the main thread.